### PR TITLE
tests: start of vault tests + token_register

### DIFF
--- a/contracts/testutils_test.gno
+++ b/contracts/testutils_test.gno
@@ -1,0 +1,104 @@
+package autoswap
+
+import (
+	"std"
+	"testing"
+
+	pusers "gno.land/p/demo/users"
+
+	"gno.land/r/gnoswap/v2/common"
+	"gno.land/r/gnoswap/v2/consts"
+
+	"gno.land/r/demo/wugnot"
+	"gno.land/r/gnoswap/v2/gns"
+
+	pl "gno.land/r/gnoswap/v2/pool"
+)
+
+func initPool() {
+	std.TestSetRealm(adminRealm)
+	pl.SetPoolCreationFeeByAdmin(0)
+	pl.CreatePool(consts.GNOT, consts.GNS_PATH, 500, common.TickMathGetSqrtRatioAtTick(-10000).ToString())
+}
+
+type WugnotToken struct{}
+
+func (WugnotToken) Transfer() func(to pusers.AddressOrName, amount uint64) {
+	return wugnot.Transfer
+}
+func (WugnotToken) TransferFrom() func(from, to pusers.AddressOrName, amount uint64) {
+	return wugnot.TransferFrom
+}
+func (WugnotToken) BalanceOf() func(owner pusers.AddressOrName) uint64 {
+	return wugnot.BalanceOf
+}
+func (WugnotToken) Approve() func(spender pusers.AddressOrName, amount uint64) {
+	return wugnot.Approve
+}
+
+type GNSToken struct{}
+
+func (GNSToken) Transfer() func(to pusers.AddressOrName, amount uint64) {
+	return gns.Transfer
+}
+
+func (GNSToken) TransferFrom() func(from, to pusers.AddressOrName, amount uint64) {
+	return gns.TransferFrom
+}
+
+func (GNSToken) BalanceOf() func(owner pusers.AddressOrName) uint64 {
+	return gns.BalanceOf
+}
+
+func (GNSToken) Approve() func(spender pusers.AddressOrName, amount uint64) {
+	return gns.Approve
+}
+
+func initTokenRegistries() {
+	RegisterGRC20Interface("gno.land/r/demo/wugnot", WugnotToken{})
+	RegisterGRC20Interface("gno.land/r/gnoswap/v2/gns", GNSToken{})
+
+	tokenRegisterRealm := std.NewUserRealm(consts.TOKEN_REGISTER)
+	std.TestSetRealm(tokenRegisterRealm)
+
+	pl.RegisterGRC20Interface("gno.land/r/demo/wugnot", WugnotToken{})
+	pl.RegisterGRC20Interface("gno.land/r/gnoswap/v2/gns", GNSToken{})
+}
+
+func a2u(addr std.Address) pusers.AddressOrName {
+	return pusers.AddressOrName(addr)
+}
+
+func shouldEQ(t *testing.T, got, expected interface{}) {
+	if got != expected {
+		t.Errorf("got %v, expected %v", got, expected)
+	}
+}
+
+func shouldNEQ(t *testing.T, got, expected interface{}) {
+	if got == expected {
+		t.Errorf("got %v, didn't expected %v", got, expected)
+	}
+}
+
+func shouldPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	f()
+}
+
+func shouldPanicWithMsg(t *testing.T, f func(), msg string) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		} else {
+			if r != msg {
+				t.Errorf("excepted panic(%v), got(%v)", msg, r)
+			}
+		}
+	}()
+	f()
+}

--- a/contracts/token_register_test.gno
+++ b/contracts/token_register_test.gno
@@ -1,0 +1,51 @@
+package autoswap
+
+import (
+	"std"
+	"testing"
+)
+
+func TestRegisterGRC20InterfaceNotAsAdmin(t *testing.T) {
+	std.TestSetRealm(fresh02Realm)
+
+	shouldPanic(t, func() {
+		RegisterGRC20Interface("pkgPath", GNSToken{})
+	})
+}
+
+func TestRegisterGRC20Interface(t *testing.T) {
+	RegisterGRC20Interface("pkgPath", GNSToken{})
+
+	grc20, found := registered.Get("pkgPath")
+
+	shouldEQ(t, found, true)
+	shouldEQ(t, grc20, GNSToken{})
+}
+
+func TestRegisterGRC20InterfaceAlreadyRegistered(t *testing.T) {
+	shouldPanic(t, func() {
+		RegisterGRC20Interface("pkgPath", GNSToken{})
+	})
+}
+
+func TestUnregisterGRC20InterfaceNotAsAdmin(t *testing.T) {
+	std.TestSetRealm(fresh02Realm)
+
+	shouldPanic(t, func() {
+		UnregisterGRC20Interface("pkgPath")
+	})
+}
+
+func TestUnregisterGRC20Interface(t *testing.T) {
+	UnregisterGRC20Interface("pkgPath")
+
+	_, found := registered.Get("pkgPath")
+
+	shouldEQ(t, found, false)
+}
+
+func TestUnregisterGRC20InterfaceNotRegistered(t *testing.T) {
+	shouldPanic(t, func() {
+		UnregisterGRC20Interface("pkgPath")
+	})
+}

--- a/contracts/vault_test.gno
+++ b/contracts/vault_test.gno
@@ -1,1 +1,58 @@
-package gnoswap_optimizer
+package autoswap
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/r/gnoswap/v2/consts"
+	"gno.land/r/demo/wugnot"
+	"gno.land/r/gnoswap/v2/gns"
+)
+
+func TestCreateVaultAsAdmin(t *testing.T) {
+	initTokenRegistries()
+	initPool()
+
+	gns.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)    // POOL FOR MINT
+	wugnot.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX) // POOL FOR MINT
+
+	// NewVault(
+	// 	consts.GNS_PATH, // token0
+	// 	consts.GNOT,     // token1
+	// 	500,          // fee
+	// 	12000,           // tickLower
+	// 	14000,           // tickUpper
+	// 	"10000000",      // amount0Desired
+	// 	"10000000",      // amount1Desired
+	// 	"0",             // amount0Min
+	// 	"0",             // amount1Min
+	// 	9999999999999999,     // deadline
+	// )
+}
+
+func TestAddKeeperNotAdmin(t *testing.T) {
+	std.TestSetRealm(fresh02Realm)
+
+	shouldPanic(t, func() {
+		AddKeeper(fresh02)
+	})
+}
+
+func TestAddKeeperAsAdmin(t *testing.T) {
+	AddKeeper(fresh02)
+
+	hasRole := accessControl.HasRole(fresh02, "keeper")
+	shouldEQ(t, hasRole, true)
+}
+
+// func TestRemoveKeeperAsAdmin(t *testing.T) {
+// 	RemoveKeeper(fresh02)
+// }
+//
+// func TestRemoveKeeperNotAdmin(t *testing.T) {
+// 	std.TestSetRealm(fresh02Realm)
+//
+// 	shouldPanic(t, func() {
+// 		RemoveKeeper(fresh02)
+// 	})
+// }


### PR DESCRIPTION
This PR is extracted from #4

It is focused on adding:
- the new token_register tests
- the start of the vault tests while trying to figure out a way to mock balances of the GRC20s